### PR TITLE
refactor: split landing page into components

### DIFF
--- a/resources/css/landing.css
+++ b/resources/css/landing.css
@@ -1,0 +1,74 @@
+body {
+    font-family: 'Inter', sans-serif;
+}
+
+.hero-gradient {
+    background: linear-gradient(135deg, #0f172a 0%, #1e3a8a 50%, #3b82f6 100%);
+}
+
+.floating-animation {
+    animation: float 6s ease-in-out infinite;
+}
+
+@keyframes float {
+    0%, 100% { transform: translateY(0px); }
+    50% { transform: translateY(-20px); }
+}
+
+.pulse-glow {
+    animation: pulse-glow 2s infinite;
+}
+
+@keyframes pulse-glow {
+    0%, 100% { box-shadow: 0 0 20px rgba(59, 130, 246, 0.3); }
+    50% { box-shadow: 0 0 40px rgba(59, 130, 246, 0.6); }
+}
+
+.slide-in-up {
+    animation: slideInUp 1s ease-out;
+}
+
+@keyframes slideInUp {
+    from {
+        opacity: 0;
+        transform: translateY(50px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.fade-in {
+    animation: fadeIn 1.5s ease-out;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.undip-logo {
+    width: 60px;
+    height: 60px;
+    background: linear-gradient(135deg, #3b82f6, #60a5fa);
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 8px 32px rgba(59, 130, 246, 0.3);
+}
+
+.glass-effect {
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.progress-bar {
+    transition: width 0.3s ease;
+}
+
+.modal {
+    backdrop-filter: blur(10px);
+}

--- a/resources/views/components/landing/footer.blade.php
+++ b/resources/views/components/landing/footer.blade.php
@@ -1,0 +1,30 @@
+<footer class="relative z-10 bg-navy-950/90 backdrop-blur-lg border-t border-navy-800/50 py-8">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex flex-col md:flex-row items-center justify-between">
+            <div class="flex items-center space-x-4 mb-4 md:mb-0">
+                <div class="undip-logo">
+                    <svg class="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 2L2 7v10c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V7l-10-5z"/>
+                    </svg>
+                </div>
+                <div>
+                    <p class="text-blue-200 text-sm font-medium">Direktorat Sumber Daya Manusia</p>
+                    <p class="text-blue-300 text-xs">Universitas Diponegoro</p>
+                </div>
+            </div>
+
+            <div class="text-center md:text-right">
+                <p class="text-blue-300 text-sm">© 2025 Direktorat SDM Universitas Diponegoro</p>
+                <p class="text-blue-400 text-xs mt-1">Jl. Prof. Soedarto, SH, Tembalang, Semarang 50275</p>
+            </div>
+        </div>
+
+        <div class="mt-6 pt-6 border-t border-navy-800/50 flex justify-center space-x-6">
+            <a href="#" class="text-blue-300 hover:text-white transition-colors duration-300"><i class="fab fa-facebook-f text-lg"></i></a>
+            <a href="#" class="text-blue-300 hover:text-white transition-colors duration-300"><i class="fab fa-twitter text-lg"></i></a>
+            <a href="#" class="text-blue-300 hover:text-white transition-colors duration-300"><i class="fab fa-instagram text-lg"></i></a>
+            <a href="#" class="text-blue-300 hover:text-white transition-colors duration-300"><i class="fab fa-youtube text-lg"></i></a>
+            <a href="#" class="text-blue-300 hover:text-white transition-colors duration-300"><i class="fas fa-globe text-lg"></i></a>
+        </div>
+    </div>
+</footer>

--- a/resources/views/components/landing/hero.blade.php
+++ b/resources/views/components/landing/hero.blade.php
@@ -1,0 +1,75 @@
+<main class="relative min-h-screen flex items-center justify-center px-4 sm:px-6 lg:px-8">
+    <div class="absolute inset-0 overflow-hidden">
+        <div class="absolute top-1/4 left-1/4 w-64 h-64 bg-blue-500/10 rounded-full blur-3xl floating-animation"></div>
+        <div class="absolute bottom-1/4 right-1/4 w-96 h-96 bg-blue-400/10 rounded-full blur-3xl floating-animation" style="animation-delay: -3s;"></div>
+        <div class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-128 h-128 bg-navy-600/5 rounded-full blur-3xl"></div>
+    </div>
+
+    <div class="relative z-10 text-center max-w-5xl mx-auto">
+        <div class="slide-in-up">
+            <h1 class="text-5xl md:text-7xl lg:text-8xl font-black text-white mb-6 leading-tight">
+                Pelatihan
+                <span class="block bg-gradient-to-r from-blue-400 via-blue-300 to-cyan-300 bg-clip-text text-transparent">
+                    PEKERTI
+                </span>
+            </h1>
+        </div>
+
+        <div class="slide-in-up" style="animation-delay: 0.3s;">
+            <p class="text-xl md:text-2xl lg:text-3xl text-blue-100 font-light mb-4 leading-relaxed">
+                Peningkatan Keterampilan Dasar Teknik Instruksional
+            </p>
+            <p class="text-lg md:text-xl text-blue-200 font-medium mb-12">
+                Direktorat Sumber Daya Manusia – Universitas Diponegoro
+            </p>
+        </div>
+
+        <div class="slide-in-up space-y-6" style="animation-delay: 0.6s;">
+            <div class="mb-8">
+                <a href="{{ route('register') }}" class="group relative inline-flex items-center justify-center px-12 py-6 text-xl font-bold text-white bg-gradient-to-r from-blue-500 to-blue-600 rounded-2xl shadow-2xl hover:from-blue-600 hover:to-blue-700 transform hover:scale-105 transition-all duration-300 pulse-glow">
+                    <i class="fas fa-user-plus mr-4 text-2xl"></i>
+                    <span>Daftar Sekarang</span>
+                    <div class="absolute inset-0 bg-gradient-to-r from-blue-400 to-blue-500 rounded-2xl opacity-0 group-hover:opacity-20 transition-opacity duration-300"></div>
+                </a>
+            </div>
+
+            <div class="flex flex-col sm:flex-row items-center justify-center space-y-4 sm:space-y-0 sm:space-x-6">
+                <a href="{{ route('login') }}" class="glass-effect px-8 py-4 text-white font-semibold rounded-xl hover:bg-white/20 transition-all duration-300 transform hover:scale-105 shadow-lg">
+                    <i class="fas fa-sign-in-alt mr-3"></i>
+                    Login Peserta
+                </a>
+
+                <a href="#" class="glass-effect px-8 py-4 text-white font-semibold rounded-xl hover:bg-white/20 transition-all duration-300 transform hover:scale-105 shadow-lg">
+                    <i class="fas fa-user-shield mr-3"></i>
+                    Login Admin
+                </a>
+            </div>
+        </div>
+
+        <div class="slide-in-up mt-20 grid grid-cols-1 md:grid-cols-3 gap-8" style="animation-delay: 0.9s;">
+            <div class="glass-effect p-6 rounded-xl text-center hover:bg-white/20 transition-all duration-300">
+                <div class="bg-blue-500/20 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+                    <i class="fas fa-graduation-cap text-2xl text-blue-300"></i>
+                </div>
+                <h3 class="text-white font-semibold mb-2">21 Modul Pembelajaran</h3>
+                <p class="text-blue-200 text-sm">Materi komprehensif untuk pengembangan kompetensi dosen</p>
+            </div>
+
+            <div class="glass-effect p-6 rounded-xl text-center hover:bg-white/20 transition-all duration-300">
+                <div class="bg-green-500/20 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+                    <i class="fas fa-certificate text-2xl text-green-300"></i>
+                </div>
+                <h3 class="text-white font-semibold mb-2">Sertifikat Resmi</h3>
+                <p class="text-blue-200 text-sm">Sertifikat yang diakui untuk pengembangan karir dosen</p>
+            </div>
+
+            <div class="glass-effect p-6 rounded-xl text-center hover:bg-white/20 transition-all duration-300">
+                <div class="bg-purple-500/20 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+                    <i class="fas fa-users text-2xl text-purple-300"></i>
+                </div>
+                <h3 class="text-white font-semibold mb-2">Pembelajaran Interaktif</h3>
+                <p class="text-blue-200 text-sm">Metode pembelajaran modern dengan pendekatan praktis</p>
+            </div>
+        </div>
+    </div>
+</main>

--- a/resources/views/components/landing/loading.blade.php
+++ b/resources/views/components/landing/loading.blade.php
@@ -1,0 +1,6 @@
+<div id="loadingOverlay" class="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 hidden flex items-center justify-center">
+    <div class="bg-white/10 backdrop-blur-lg rounded-xl p-8 text-center">
+        <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-white mx-auto mb-4"></div>
+        <p class="text-white">Memproses...</p>
+    </div>
+</div>

--- a/resources/views/components/landing/nav.blade.php
+++ b/resources/views/components/landing/nav.blade.php
@@ -1,0 +1,24 @@
+<header class="relative z-10 bg-navy-950/80 backdrop-blur-lg border-b border-navy-800/50">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex items-center justify-between py-4">
+            <div class="flex items-center space-x-4 fade-in">
+                <div class="undip-logo">
+                    <svg class="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 2L2 7v10c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V7l-10-5z"/>
+                        <path d="M12 7v10l-7-3.5V9l7-2z" fill="rgba(255,255,255,0.3)"/>
+                    </svg>
+                </div>
+                <div>
+                    <h1 class="text-xl font-bold text-white">UNDIP</h1>
+                    <p class="text-xs text-blue-200">Universitas Diponegoro</p>
+                </div>
+            </div>
+
+            <nav class="hidden md:flex items-center space-x-6 fade-in">
+                <a href="#tentang" class="text-blue-200 hover:text-white transition-colors duration-300 text-sm font-medium">Tentang</a>
+                <a href="#program" class="text-blue-200 hover:text-white transition-colors duration-300 text-sm font-medium">Program</a>
+                <a href="#kontak" class="text-blue-200 hover:text-white transition-colors duration-300 text-sm font-medium">Kontak</a>
+            </nav>
+        </div>
+    </div>
+</header>

--- a/resources/views/components/landing/notification.blade.php
+++ b/resources/views/components/landing/notification.blade.php
@@ -1,0 +1,15 @@
+<div id="notification" class="fixed top-4 right-4 z-50 hidden">
+    <div class="bg-white border-l-4 border-green-500 rounded-lg shadow-lg p-4 max-w-sm">
+        <div class="flex items-center">
+            <div class="flex-shrink-0">
+                <i class="fas fa-check-circle text-green-500"></i>
+            </div>
+            <div class="ml-3">
+                <p id="notification-text" class="text-sm text-gray-700"></p>
+            </div>
+            <button onclick="hideNotification()" class="ml-auto text-gray-400 hover:text-gray-600">
+                <i class="fas fa-times"></i>
+            </button>
+        </div>
+    </div>
+</div>

--- a/resources/views/components/layouts/landing.blade.php
+++ b/resources/views/components/layouts/landing.blade.php
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ $title ?? 'Pelatihan PEKERTI - Universitas Diponegoro' }}</title>
+    @vite(['resources/css/app.css', 'resources/css/landing.css', 'resources/js/app.js'])
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+</head>
+<body class="min-h-screen hero-gradient">
+    @include('components.landing.notification')
+    @include('components.landing.loading')
+    <x-landing.nav />
+    {{ $slot }}
+    <x-landing.footer />
+</body>
+</html>

--- a/resources/views/pages/landing.blade.php
+++ b/resources/views/pages/landing.blade.php
@@ -1,0 +1,3 @@
+<x-layouts.landing>
+    <x-landing.hero />
+</x-layouts.landing>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,9 +3,11 @@
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
-});
+Route::view('/', 'pages.landing')->name('landing');
+// Suggested future routes for content sections
+// Route::view('/about', 'pages.about')->name('about');
+// Route::view('/program', 'pages.program')->name('program');
+// Route::view('/contact', 'pages.contact')->name('contact');
 
 Route::get('/dashboard', function () {
     return view('dashboard');

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,21 @@ export default {
             fontFamily: {
                 sans: ['Figtree', ...defaultTheme.fontFamily.sans],
             },
+            colors: {
+                navy: {
+                    50: '#f0f4ff',
+                    100: '#e0e9ff',
+                    200: '#c7d6fe',
+                    300: '#a5b8fc',
+                    400: '#8b93f8',
+                    500: '#7c6df2',
+                    600: '#6d4de6',
+                    700: '#5d3dcb',
+                    800: '#4c32a4',
+                    900: '#1e3a8a',
+                    950: '#0f172a',
+                },
+            },
         },
     },
 


### PR DESCRIPTION
## Summary
- break monolithic `landing.blade.php` into layout and Blade components (nav, hero, footer)
- extract custom styles into `resources/css/landing.css`
- root route now serves modular landing page with suggested future routes

## Testing
- `npm run build`
- `php artisan test` *(fails: missing vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_68b53f6fd64c832799ac62654430b30d